### PR TITLE
제22조 제5항의 오류 수정 및 사소한 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# PoolC 회칙
+
+연세대학교 공학대학 프로그래밍 학술동아리 PoolC의 회칙입니다.
+
+[여기](http://poolc.github.io/Regulation/)에서 확인하실 수 있습니다.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>PoolC 회칙 by PoolC</title>
+    <title>PoolC 회칙</title>
 
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
@@ -17,15 +17,6 @@
       <header>
         <h1>PoolC 회칙</h1>
         <p>연세대학교 공학대학 프로그래밍 학술동아리 PoolC의 회칙입니다.</p>
-
-        <p class="view"><a href="https://github.com/PoolC/Regulation">View the Project on GitHub <small>PoolC/Regulation</small></a></p>
-
-
-        <ul>
-          <li><a href="https://github.com/PoolC/Regulation/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/PoolC/Regulation/tarball/master">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="https://github.com/PoolC/Regulation">View On <strong>GitHub</strong></a></li>
-        </ul>
       </header>
       <section>
         <h2>
@@ -371,7 +362,7 @@
 <li>변호인은 징계대상자를 변호하여 부당 행위가 없었음을 주장하거나 징계 수위를 낮추기 위해 노력한다.</li>
 <li>배심원단은 징계위원장, 징계대상자와 변호인의 의견을 검토하여 징계 여부와 제26조에 의거하여 징계의 종류와 수위를 결정한다.</li>
 <li>징계위원장, 징계대상자와 변호인은 징계 결과에 대해 이의 제기를 1회 할 수 있다.</li>
-<li>이의제기가 있을 경우 제14조 제4항에 따라 배심원단을 다시 선발하여 새로운 배심원단이 판단하도록 한다.</li>
+<li>이의제기가 있을 경우 제21조 제4항에 따라 배심원단을 다시 선발하여 새로운 배심원단이 판단하도록 한다.</li>
 </ol>
 
 <h3>


### PR DESCRIPTION
**1. 제22조 제5항의 오류 수정**

`제14조 제4항`으로 잘못 명시되어 있던 배심원단 선발 기준을 `제21조 제4항`으로 정정했습니다.

**2. GitHub Pages 디자인의 사소한 수정**

ZIP, TAR 등으로 다운받는 기능을 제거했습니다.

**3. README 추가**

레포지토리에서 쉽게 GitHub Pages로 이동할 수 있도록 링크를 추가했습니다.